### PR TITLE
GH-7: 增加中文 README 说明（rehearsal retry）

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NightShift is an overnight AI coding harness. This repository now contains both 
 - `docs/mvp-walkthrough.md`: implementation-facing usage notes for the current MVP
 - `docs/2026-03-28-workflow-verification-report.md`: real operator rehearsal results and confirmed workflow gaps
 - `docs/local-development.md`: safe local execution guidance for multi-worktree development
+- `docs/architecture/README.md`: current architecture entry point, split into kernel and product workflow views
 
 ## Current Recommended Entry Points
 
@@ -27,6 +28,7 @@ NightShift is an overnight AI coding harness. This repository now contains both 
 - MVP walkthrough: `docs/mvp-walkthrough.md`
 - Latest workflow verification: `docs/2026-03-28-workflow-verification-report.md`
 - Local development note: `docs/local-development.md`
+- Architecture entry point: `docs/architecture/README.md`
 
 ## Current MVP Boundaries
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NightShift
 
+> Language / 语言：English | [简体中文](README.zh-CN.md)
+
 NightShift is an overnight AI coding harness. This repository now contains both the `v4.2.1` architecture spec set and a Python MVP kernel that can execute a single issue, validate it, recover interrupted runs, and emit a minimal historical report.
 
 ## Current Status

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,80 @@
+# NightShift
+
+> Language / 语言：[English](README.md) | 简体中文
+
+NightShift 是一个面向夜间运行场景的 AI 编码执行框架。当前仓库同时包含 `v4.2.1` 架构规范集合，以及一个 Python MVP 内核。这个 MVP 已经可以执行单个 issue、运行验证、恢复中断的运行流程，并产出最小化的历史报告。
+
+## 当前状态
+
+- 当前实现目标：`v4.2.1`
+- 当前 CLI 命令面：`run-one`、`recover`、`report`、`queue status`、`queue show`、`queue reprioritize`
+- 当前引擎适配器：`codex`、`claude`
+- 当前范围：单 issue 执行流程，以及持久化、验证、恢复、按 run 范围生成报告
+
+## 仓库结构
+
+- `src/nightshift/`：Python MVP 内核实现
+- `tests/`：可执行行为测试与回归覆盖
+- `examples/`：配置样例与 issue 合约样例
+- `docs/superpowers/specs/`：架构演进历史与当前规范集合
+- `docs/mvp-walkthrough.md`：面向实现的当前 MVP 使用说明
+- `docs/2026-03-28-workflow-verification-report.md`：真实操作员演练结果与已确认的工作流缺口
+- `docs/local-development.md`：多 worktree 场景下的本地安全执行说明
+- `docs/architecture/README.md`：当前架构入口，拆分为 kernel 与产品工作流两个视角
+
+## 当前推荐入口
+
+- 规范索引：`docs/superpowers/specs/README.md`
+- 当前架构：`docs/superpowers/specs/2026-03-27-nightshift-v4.2.1-unified-spec.md`
+- 当前详细设计包：`docs/superpowers/specs/nightshift-v4.2.1/README.md`
+- MVP 使用说明：`docs/mvp-walkthrough.md`
+- 最新工作流验证：`docs/2026-03-28-workflow-verification-report.md`
+- 本地开发说明：`docs/local-development.md`
+- 架构入口：`docs/architecture/README.md`
+
+## 当前 MVP 边界
+
+当前已经可用的能力：
+
+- 加载 `nightshift.yaml`
+- 读取不可变 issue 合约与当前 issue 记录
+- 创建 issue worktree 与快照
+- 通过一个选定的引擎适配器执行：`codex` 或 `claude`
+- 运行验证门禁
+- 持久化 run 状态、issue 快照、attempt 记录、事件与告警
+- 将中断的 run 恢复为一个新的控制 run
+- 基于 run 范围内的持久化历史生成最小报告
+
+当前引擎选择语义：
+
+- `run-one` 每次 attempt 只选择一个引擎
+- 选择顺序是 `IssueContract.engine_preferences.primary`，然后 `runner.default_engine`
+- `engine_preferences.fallback` 与 `runner.fallback_engine` 目前仍是预留 schema 字段
+- MVP 执行框架在失败后不会自动切换引擎；操作员应直接检查持久化的 attempt 记录与产物
+
+当前 MVP 明确尚未包含的能力：
+
+- requirement splitter
+- PR 分发与合并自动化
+- 通知与仪表盘
+- 超出当前 queue 原语范围之外的无人值守多 issue 夜间调度策略
+
+## 剩余的非 MVP 缺口
+
+当前分支刻意不是一个完整的 `v4.2.1` 产品级实现。下面这些缺口是已知范围，不属于当前 MVP 范围内的 bug：
+
+- 还没有 issue 导入流程：执行前仍需先准备好合约和当前 issue 记录
+- 还没有多 issue 夜间控制循环：目前只有 `run-one`，`run`、`run --daemon`、`stop` 尚未实现
+- 还没有队列接纳命令：`queue add` 仍然缺失
+- 还没有交付自动化：branch 交接、PR 打开、review 同步、merge 工作流尚未接线
+- 还没有操作员日志视图：`logs --issue` 尚未实现
+- `retry`、`alerts`、顶层验证命令组等配置段已经建模，但在 MVP 中只做了最小接线
+- 还没有更丰富的晨间报告生成器，目前只有最小 JSON 历史报告
+
+## 本地验证
+
+```bash
+python -m pytest -v
+```
+
+如果你在多个 worktree 或多个 editable install 之间工作，请先阅读 `docs/local-development.md`，并优先使用显式的 `PYTHONPATH` 与明确的解释器路径。

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,30 @@
+# NightShift Architecture
+
+This directory is the current architecture entry point for the repository.
+
+It exists to separate two different questions that were previously mixed together:
+
+- what part of NightShift is already implemented and verified
+- what part of NightShift still belongs to the broader product workflow
+
+## Current Status
+
+- kernel: implemented and verified
+- product workflow: partially designed, not fully implemented
+
+## Reading Guide
+
+Start here when you need to understand the current system boundary:
+
+- [kernel/README.md](./kernel/README.md)
+- [product/README.md](./product/README.md)
+
+## Relationship To The Spec Set
+
+The full design history and the active `v4.2.1` spec set still live under:
+
+- `docs/superpowers/specs/`
+
+Use this `docs/architecture/` directory as the shortest route to the current architectural picture.
+
+Use `docs/superpowers/specs/` when you need the full normative design detail or design history.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,10 +7,22 @@ It exists to separate two different questions that were previously mixed togethe
 - what part of NightShift is already implemented and verified
 - what part of NightShift still belongs to the broader product workflow
 
+This directory is a working architecture view, not a declaration that the current Python package layout is final.
+
+Its purpose is to make the next design and implementation steps easier to reason about.
+
 ## Current Status
 
 - kernel: implemented and verified
 - product workflow: partially designed, not fully implemented
+
+## Boundary Confidence
+
+The `kernel` vs `product workflow` split should currently be read as a planning and ownership boundary.
+
+It is grounded in the `v4.2.1` architecture, but it is still a working agreement.
+
+It does not yet imply that every source directory or module has been permanently classified.
 
 ## Reading Guide
 

--- a/docs/architecture/kernel/README.md
+++ b/docs/architecture/kernel/README.md
@@ -2,6 +2,8 @@
 
 This section describes the NightShift kernel as it is defined in `v4.2.1` and as it exists in the current repository.
 
+It is intentionally a boundary description, not a claim that the current source tree is already physically organized as a dedicated `kernel/` package.
+
 ## Kernel Status
 
 The kernel is treated as implemented and verified.
@@ -11,6 +13,8 @@ That statement means:
 - the stable kernel modules from `v4.2.1` exist in code
 - the supporting persistence and workspace layers required by the kernel also exist
 - the kernel has passed both automated verification and real operator-style rehearsal within its current scope
+
+This status is about capability and verification, not about final directory structure.
 
 ## What Counts As The Kernel
 
@@ -25,6 +29,10 @@ Supporting infrastructure that is required for the kernel to function:
 
 - Workspace Manager
 - State Store
+
+This should be read as the current architectural ownership boundary for the repository.
+
+It should not yet be read as a promise that every current module placement is final.
 
 ## What The Kernel Can Do Today
 

--- a/docs/architecture/kernel/README.md
+++ b/docs/architecture/kernel/README.md
@@ -1,0 +1,65 @@
+# NightShift Kernel
+
+This section describes the NightShift kernel as it is defined in `v4.2.1` and as it exists in the current repository.
+
+## Kernel Status
+
+The kernel is treated as implemented and verified.
+
+That statement means:
+
+- the stable kernel modules from `v4.2.1` exist in code
+- the supporting persistence and workspace layers required by the kernel also exist
+- the kernel has passed both automated verification and real operator-style rehearsal within its current scope
+
+## What Counts As The Kernel
+
+Per `v4.2.1`, the stable kernel consists of:
+
+- Issue Registry
+- Run Orchestrator
+- Engine Adapter Layer
+- Validation Gate
+
+Supporting infrastructure that is required for the kernel to function:
+
+- Workspace Manager
+- State Store
+
+## What The Kernel Can Do Today
+
+- load immutable issue contracts and current issue records
+- inspect the current queue
+- execute one issue with `run-one`
+- validate and accept or reject an attempt
+- persist run state, attempt history, issue snapshots, events, and alerts
+- recover interrupted runs
+- generate a minimal historical run report
+
+## Verification Basis
+
+The kernel has been validated through:
+
+- automated test coverage in `tests/`
+- full suite verification
+- operator-style workflow rehearsal captured in:
+  - `docs/2026-03-28-workflow-verification-report.md`
+
+## Key Source Documents
+
+- `docs/superpowers/specs/2026-03-27-nightshift-v4.2.1-unified-spec.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/01-domain-model.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/02-kernel-interfaces.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/03-state-machines.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/04-engine-adapters-and-workspaces.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/06-cli-config-persistence-alerting.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/07-language-and-phasing.md`
+
+## Code Entry Points
+
+- `src/nightshift/registry/`
+- `src/nightshift/orchestrator/`
+- `src/nightshift/engines/`
+- `src/nightshift/validation/`
+- `src/nightshift/workspace/`
+- `src/nightshift/store/`

--- a/docs/architecture/product/README.md
+++ b/docs/architecture/product/README.md
@@ -1,0 +1,55 @@
+# NightShift Product Workflow
+
+This section describes the parts of NightShift that sit above the kernel and are not yet complete in the current repository.
+
+## Product Workflow Status
+
+The broader product workflow is not yet fully implemented.
+
+The kernel can already execute approved work once an execution-ready issue exists.
+
+What is still missing is the workflow around getting work into the kernel and delivering the result back out.
+
+## What Belongs To Product Workflow
+
+These areas are outside the stable kernel boundary in `v4.2.1`:
+
+- requirement splitter
+- proposal review and approval flow
+- issue ingestion into execution-ready contracts
+- queue admission commands such as `queue add`
+- multi-issue overnight control loop
+- notifications
+- richer reporting
+- PR dispatcher and delivery automation
+
+## Important Boundary
+
+Today the repository supports:
+
+- execution-ready issue in
+- kernel execution
+- run history out
+
+It does not yet support the full product chain:
+
+- external request in
+- automated proposal and approval
+- automated delivery and PR creation
+
+## Design Sources
+
+The main design references for the product workflow side are:
+
+- `docs/superpowers/specs/nightshift-v4.2.1/05-requirement-splitter-and-context-loading.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/06-cli-config-persistence-alerting.md`
+- `docs/superpowers/specs/nightshift-v4.2.1/07-language-and-phasing.md`
+
+## Current Next-Step Theme
+
+The next meaningful step above the kernel is a minimal issue-ingestion path that can turn an external request into:
+
+- immutable `IssueContract`
+- current `IssueRecord`
+
+without requiring manual hand-authoring of both files every time.

--- a/docs/architecture/product/README.md
+++ b/docs/architecture/product/README.md
@@ -2,6 +2,8 @@
 
 This section describes the parts of NightShift that sit above the kernel and are not yet complete in the current repository.
 
+It should be read as the current product-layer planning boundary, not as a final code-layout commitment.
+
 ## Product Workflow Status
 
 The broader product workflow is not yet fully implemented.
@@ -9,6 +11,8 @@ The broader product workflow is not yet fully implemented.
 The kernel can already execute approved work once an execution-ready issue exists.
 
 What is still missing is the workflow around getting work into the kernel and delivering the result back out.
+
+This is the area where the architecture is still expected to evolve the most.
 
 ## What Belongs To Product Workflow
 
@@ -22,6 +26,10 @@ These areas are outside the stable kernel boundary in `v4.2.1`:
 - notifications
 - richer reporting
 - PR dispatcher and delivery automation
+
+These items are grouped here as the current product-work boundary for planning purposes.
+
+That grouping may still be refined as implementation work exposes better seams.
 
 ## Important Boundary
 

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -2,6 +2,12 @@
 
 This index exists to keep implementation work anchored to one active design target and to prevent older design iterations from polluting the default reading path.
 
+For the shortest current-state architecture view, also see:
+
+- `docs/architecture/README.md`
+- `docs/architecture/kernel/README.md`
+- `docs/architecture/product/README.md`
+
 ## Current Implementation Target
 
 The current implementation target is:


### PR DESCRIPTION
## Summary
- Delivered by NightShift for #7

## Acceptance
- 仓库根目录存在 README.zh-CN.md
- 根 README.md 顶部或显著位置有中文入口
- 中文 README 内容与当前实现状态一致

## Verification
- test -s README.zh-CN.md
- rg -n "README\.zh-CN\.md|中文" README.md

Source repository: GM-HZ/nightshift